### PR TITLE
Issue #2: Handle odd exit code from revive

### DIFF
--- a/.github/workflows/quality-and-tests.yml
+++ b/.github/workflows/quality-and-tests.yml
@@ -17,12 +17,12 @@ jobs:
         run: make install-gotestsum
       - name: Install revive
         run: go get -u github.com/mgechev/revive
-      - name: Lint the code
-        run: make lint
       - name: go mod tidy
         run: go mod tidy
       - name: go mod vendor
         run: go mod vendor
+      - name: Lint the code
+        run: make lint
       - name: Vet the code
         run: make vet
       - name: Run unit tests

--- a/.github/workflows/quality-and-tests.yml
+++ b/.github/workflows/quality-and-tests.yml
@@ -17,9 +17,8 @@ jobs:
         run: make install-gotestsum
       - name: Install revive
         run: go get -u github.com/mgechev/revive
-      # TODO: How to handle the exit code when no problems are found.
-#      - name: Lint the code
-#        run: make lint
+      - name: Lint the code
+        run: make lint
       - name: go mod tidy
         run: go mod tidy
       - name: go mod vendor

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,6 @@ repos:
       - id: end-of-file-fixer
       - id: check-merge-conflict
 
-  - repo: https://github.com/syntaqx/git-hooks
-    rev: v0.0.17
-    hooks:
-      - id: circleci-config-validate
-
   # ==========================================================================
   # Golang Pre-Commit Hooks | https://github.com/tekwizely/pre-commit-golang
 

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ analyze: lint vet test ## Run lint, vet, and test
 
 .PHONY: lint
 lint: ## Lint the code
-    # TODO: revive seems to give an error exit code even though it doesn't report any problems. How to handle?
-	@revive -config .revive.toml ./... | grep -v vendor
+	# revive returns an exit code of 1 if no issues found. Strike that; reverse it.
+	@! revive -config .revive.toml ./... | grep -v vendor
 
 .PHONY: test
 test: unit-test ## Run the test suite(s).


### PR DESCRIPTION
- Invert the exit code received from `revive`.
- Enable lint in GitHub actions.
- Remove CircleCI pre-commit hook.