### PR TITLE
Issue #3: Add "Development" section / document

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 This package is designed to help with handling errors from databases and web services. The `glitch.DataError` structure
 allows the logic layer of your code to use its error code to handle each machine-readable code in a user-friendly way.
 
+Interested in making this library better? Read through our [development guide](docs/development.md).
+
 ## PostgreSQL errors
 
 You can convert a `lib/pq` error into a `glitch.DataError` using `postgres.ToDataError()`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,35 @@
+# Development
+
+## Tooling
+
+- [asdf](https://asdf-vm.com/) - Extendable version manager with support for Ruby, Node.js, Erlang & more
+- [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) - Updates your Go import lines, adding missing ones and removing unreferenced ones. Also formats your code in the same style as `gofmt`.
+- [gotestsum](https://github.com/gotestyourself/gotestsum) - 'go test' runner with output optimized for humans, JUnit XML for CI integration, and a summary of the test results.
+- [revive](https://github.com/mgechev/revive) - Fast, configurable, extensible, flexible, and beautiful linter for Go.
+- [pre-commit](https://pre-commit.com/) - Framework for managing multi-language pre-commit hooks
+
+## Setup local environment
+
+### OS X
+
+```shell
+make setup-osx-env
+```
+
+This uses [Homebrew](https://brew.sh/) to install the `revive`, `asdf`, and `pre-commit` tools. It then uses `asdf` to
+install the version of Go specified in `.tool-versions`, downloads the `goimports` and `gotestsum` tools, and sets up
+the pre-commit hooks configured in `.pre-commit-config.yml`.
+
+## GitHub pre-commit hooks
+
+This project uses [pre-commit](https://pre-commit.com/) to run lint, vet, and unit check tests before you commit any
+code.
+
+
+## Continuous Integration
+This project uses [GitHub Actions](https://github.com/sprak3000/go-glitch/actions) for build and continuous integration.
+
+## Code Quality
+
+This project uses [CodeClimate](https://codeclimate.com/github/sprak3000/go-glitch) to track code quality metrics and
+trends.


### PR DESCRIPTION
- Add document outlining how to setup development environment, tooling used, etc.
- Link to document in `README`.

Closes #3.