### PR TITLE
Issue #9 - Fix go.mod module package path

### DIFF
--- a/.github/workflows/quality-and-tests.yml
+++ b/.github/workflows/quality-and-tests.yml
@@ -32,4 +32,4 @@ jobs:
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_TEST_REPORTER_ID }}
         with:
-          prefix: go-glitch
+          prefix: github.com/sprak3000/go-glitch

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go-glitch
+module github.com/sprak3000/go-glitch
 
 go 1.17
 

--- a/postgres/pg.go
+++ b/postgres/pg.go
@@ -3,7 +3,7 @@ package postgres
 import (
 	"github.com/lib/pq"
 
-	"go-glitch/glitch"
+	"github.com/sprak3000/go-glitch/glitch"
 )
 
 // ToDataError will convert a lib/pq error into a DataError

--- a/postgres/pg_test.go
+++ b/postgres/pg_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 
-	"go-glitch/glitch"
+	"github.com/sprak3000/go-glitch/glitch"
 )
 
 func TestUnit_ToDataError(t *testing.T) {


### PR DESCRIPTION
- Update to proper form of `github.com/sprak3000/go-glitch` for package path.
- Update code to account for this change.
- Update GitHub actions configuration.

Closes #9.